### PR TITLE
Avoid interactive flag

### DIFF
--- a/Jenkinsfile.php_cli
+++ b/Jenkinsfile.php_cli
@@ -14,8 +14,8 @@ elifePipeline {
             }
 
             stage 'Sanity tests', {
-                sh "docker run -it elifesciences/php_cli:${tag} -r 'echo 42, PHP_EOL;'"
-                sh "docker run -it elifesciences/php_cli:${tag} composer -V"
+                sh "docker run elifesciences/php_cli:${tag} -r 'echo 42, PHP_EOL;'"
+                sh "docker run elifesciences/php_cli:${tag} composer -V"
             }
 
             elifeMainlineOnly {

--- a/Jenkinsfile.php_fpm
+++ b/Jenkinsfile.php_fpm
@@ -14,8 +14,8 @@ elifePipeline {
             }
 
             stage 'Sanity tests', {
-                sh "docker run -it elifesciences/php_fpm:${tag} /usr/bin/env php -r 'echo 42, PHP_EOL;'"
-                sh "docker run -it elifesciences/php_fpm:${tag} composer -V"
+                sh "docker run elifesciences/php_fpm:${tag} /usr/bin/env php -r 'echo 42, PHP_EOL;'"
+                sh "docker run elifesciences/php_fpm:${tag} composer -V"
             }
 
             elifeMainlineOnly {


### PR DESCRIPTION
As Jenkins cannot use them, being an headless process
```
12:12:17 + docker run -it elifesciences/php_cli:20180124121156 -r echo 42, PHP_EOL;
12:12:17 the input device is not a TTY
```