### PR TITLE
Install New Relic APM PHP agent in base images

### DIFF
--- a/Dockerfile.php_cli
+++ b/Dockerfile.php_cli
@@ -12,6 +12,7 @@ RUN useradd -ms /bin/bash -G www-data elife && \
 ENV PATH=/srv/bin:${PATH}
 
 COPY scripts/ /root/scripts
+RUN /root/scripts/install-newrelic-php.sh
 RUN /root/scripts/install-composer.sh
 
 USER www-data

--- a/Dockerfile.php_fpm
+++ b/Dockerfile.php_fpm
@@ -12,6 +12,7 @@ RUN useradd -ms /bin/bash -G www-data elife && \
 ENV PATH=/srv/bin:${PATH}
 
 COPY scripts/ /root/scripts
+RUN /root/scripts/install-newrelic-php.sh
 RUN /root/scripts/install-composer.sh
 
 USER www-data

--- a/config/usr-local-etc-php-conf.d-newrelic.ini
+++ b/config/usr-local-etc-php-conf.d-newrelic.ini
@@ -1,0 +1,13 @@
+# adapted from https://github.com/elifesciences/builder-base-formula/blob/master/elife/config/etc-php-7.0-sapi-conf.d-newrelic.ini
+
+extension = "newrelic.so"
+[newrelic]
+newrelic.enabled = ${NEW_RELIC_ENABLED}
+newrelic.license = ${NEW_RELIC_LICENSE_KEY}
+newrelic.appname = ${NEW_RELIC_APP_NAME}
+newrelic.logfile = "/var/log/newrelic/php_agent.log"
+newrelic.daemon.logfile = "/var/log/newrelic/newrelic-daemon.log"
+newrelic.labels = "project:${NEW_RELIC_APP_NAME};env:${ENVIRONMENT_NAME}"
+
+; Assume that the application handles errors and sends the details. See https://discuss.newrelic.com/t/how-to-disable-newrelic-set-exception-handler/35544/18
+newrelic.special = "no_exception_handler"

--- a/scripts/install-newrelic-php.sh
+++ b/scripts/install-newrelic-php.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+echo 'deb http://apt.newrelic.com/debian/ newrelic non-free' > /etc/apt/sources.list.d/newrelic.list
+curl https://download.newrelic.com/548C16BF.gpg | apt-key add -
+
+# the package contains both PHP 5 and PHP 7 support
+# https://discuss.newrelic.com/t/php-agent-and-php-7-0/27687/85
+apt-get update && apt-get install -y newrelic-php5
+
+NR_INSTALL_SILENT="set-any-value-to-enable" \
+#NR_INSTALL_KEY="fake-license" \
+newrelic-install install
+
+# adapted from https://discuss.newrelic.com/t/php-agent-configuration-in-docker-containers/41499/3
+sed -i \
+ -e "s/;\?newrelic.enabled =.*/newrelic.enabled = \${NEW_RELIC_ENABLED}/" \
+ -e "s/newrelic.license =.*/newrelic.license = \${NEW_RELIC_LICENSE_KEY}/" \
+ -e "s/newrelic.appname =.*/newrelic.appname = \${NEW_RELIC_APP_NAME}/" \
+ /usr/local/etc/php/conf.d/newrelic.ini

--- a/scripts/install-newrelic-php.sh
+++ b/scripts/install-newrelic-php.sh
@@ -9,7 +9,6 @@ curl https://download.newrelic.com/548C16BF.gpg | apt-key add -
 apt-get update && apt-get install -y newrelic-php5
 
 NR_INSTALL_SILENT="set-any-value-to-enable" \
-#NR_INSTALL_KEY="fake-license" \
 newrelic-install install
 
 # adapted from https://discuss.newrelic.com/t/php-agent-configuration-in-docker-containers/41499/3


### PR DESCRIPTION
Requires some care in setting environment variables when the container is used to actually turn New Relic on (off by default, e.g. in development).

New Relic APM requires a daemon to be run alongside the PHP processes. However the daemon is automatically launched by the extension, inside the container:
```
www-data@5a5be976269c:/$ ps faxww
  PID TTY      STAT   TIME COMMAND
   28 pts/1    Ss     0:00 /bin/bash
   34 pts/1    R+     0:00  \_ ps faxww
    1 pts/0    Ss+    0:00 php -a
   13 ?        Ssl    0:00 /usr/bin/newrelic-daemon --agent --logfile /var/log/newrelic/newrelic-daemon.log --port /tmp/.newrelic.sock --tls --define utilization.detect_aws=true --define utilization.detect_azure=true --define utilization.detect_gcp=true --define utilization.detect_pcf=true --define utilization.detect_docker=true
   18 ?        Sl     0:00  \_ /usr/bin/newrelic-daemon --agent --logfile /var/log/newrelic/newrelic-daemon.log --port /tmp/.newrelic.sock --tls --define utilization.detect_aws=true --define utilization.detect_azure=true --define utilization.detect_gcp=true --define utilization.detect_pcf=true --define utilization.detect_docker=true -no-pidfile
```