### PR TITLE
Avoid duplicating composer commands in various Dockerfiles

### DIFF
--- a/Dockerfile.php_cli
+++ b/Dockerfile.php_cli
@@ -12,6 +12,7 @@ RUN useradd -ms /bin/bash -G www-data elife && \
 ENV PATH=/srv/bin:${PATH}
 
 COPY scripts/ /root/scripts
+COPY --chown=elife:elife utils/ /srv/bin/
 RUN /root/scripts/install-newrelic-php.sh
 RUN /root/scripts/install-composer.sh
 

--- a/utils/composer-autoload-dev
+++ b/utils/composer-autoload-dev
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+exec composer --no-interaction dump-autoload --classmap-authoritative

--- a/utils/composer-autoload-prod
+++ b/utils/composer-autoload-prod
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+exec composer --no-interaction dump-autoload --no-dev --classmap-authoritative

--- a/utils/composer-install-dev
+++ b/utils/composer-install-dev
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+exec composer --no-interaction install --no-suggest --no-autoloader

--- a/utils/composer-install-prod
+++ b/utils/composer-install-prod
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+exec composer --no-interaction install --no-suggest --no-dev --no-autoloader


### PR DESCRIPTION
Will probably become `utils/php/` when Python base images appear.