### PR TITLE
Make memory_limit in PHP CLI unlimited

### DIFF
--- a/Dockerfile.php_7.0_cli
+++ b/Dockerfile.php_7.0_cli
@@ -11,5 +11,6 @@ COPY --chown=elife:elife utils/ /srv/bin/
 RUN /root/scripts/install-newrelic-php.sh
 
 COPY config/php-7.0-elife.ini ${PHP_INI_DIR}/conf.d/elife.ini
+COPY config/php-7.0-elife-cli.ini ${PHP_INI_DIR}/conf.d/elife-cli.ini
 
 USER www-data

--- a/config/php-7.0-elife-cli.ini
+++ b/config/php-7.0-elife-cli.ini
@@ -1,0 +1,1 @@
+memory_limit = -1


### PR DESCRIPTION
Made a mistake in #21, thought the default for CLI was `-1` (unlimited).

This should be fine, as a CLI instance is either one process (eg watching a queue), or running tests (ie non-production).