### PR TITLE
Wait for port 9000 in fpm smoke test

### DIFF
--- a/utils/assert_fpm
+++ b/utils/assert_fpm
@@ -22,6 +22,8 @@ fi
 path="$1"
 text="$2"
 
+wait_for_port 9000
+
 output=$(SCRIPT_FILENAME="${PROJECT_FOLDER}/${PHP_ENTRYPOINT}" REQUEST_URI="${path}" REQUEST_METHOD=GET cgi-fcgi -bind -connect 127.0.0.1:9000)
 fail() {
     echo "---Full output follows---"

--- a/utils/wait_for_port
+++ b/utils/wait_for_port
@@ -5,6 +5,8 @@ port="${1:-80}"
 timeout="${2:-60}"
 host="${3:-localhost}"
 
+echo "Checking for netcat availability: \$ which nc"
+which nc
 echo "Waiting for someone listening on port $port"
 timeout "$timeout" sh -c 'while ! nc -q0 -w1 -z '"$host"' '"$port"' </dev/null >/dev/null 2>&1; do sleep 1; done'
 echo "Connection was established on port $port"

--- a/utils/wait_for_port
+++ b/utils/wait_for_port
@@ -5,8 +5,6 @@ port="${1:-80}"
 timeout="${2:-60}"
 host="${3:-localhost}"
 
-echo "Checking for netcat availability: \$ which nc"
-which nc
 echo "Waiting for someone listening on port $port"
-timeout "$timeout" sh -c 'while ! nc -q0 -w1 -z '"$host"' '"$port"' </dev/null >/dev/null 2>&1; do sleep 1; done'
+timeout "$timeout" bash -c "while ! echo > /dev/tcp/$host/$port; do sleep 1; done"
 echo "Connection was established on port $port"


### PR DESCRIPTION
Should avoid race conditions like https://alfred.elifesciences.org/job/image/job/image-php-7.0-fpm/27/console

- [ ] make smoke test wait for port 9000
- [ ] make `wait_for_port` also work without `netcat`
- [ ] run smoke test on PR builds