### PR TITLE
Pass `Host: localhost` in healthchecks

### DIFF
--- a/utils/assert_fpm
+++ b/utils/assert_fpm
@@ -24,7 +24,7 @@ text="$2"
 
 wait_for_port 9000
 
-output=$(SCRIPT_FILENAME="${PROJECT_FOLDER}/${PHP_ENTRYPOINT}" REQUEST_URI="${path}" REQUEST_METHOD=GET cgi-fcgi -bind -connect 127.0.0.1:9000)
+output=$(SCRIPT_FILENAME="${PROJECT_FOLDER}/${PHP_ENTRYPOINT}" HTTP_HOST=localhost REQUEST_URI="${path}" REQUEST_METHOD=GET cgi-fcgi -bind -connect 127.0.0.1:9000)
 fail() {
     echo "---Full output follows---"
     echo "${output}"

--- a/utils/assert_fpm
+++ b/utils/assert_fpm
@@ -24,7 +24,7 @@ text="$2"
 
 wait_for_port 9000
 
-output=$(SCRIPT_FILENAME="${PROJECT_FOLDER}/${PHP_ENTRYPOINT}" HTTP_HOST=localhost REQUEST_URI="${path}" REQUEST_METHOD=GET cgi-fcgi -bind -connect 127.0.0.1:9000)
+output=$(SCRIPT_FILENAME="${PROJECT_FOLDER}/${PHP_ENTRYPOINT}" HTTP_HOST="${HTTP_HOST:-localhost}" REQUEST_URI="${path}" REQUEST_METHOD=GET cgi-fcgi -bind -connect 127.0.0.1:9000)
 fail() {
     echo "---Full output follows---"
     echo "${output}"


### PR DESCRIPTION
Tested on real `journal` environments, for example:
```
www-data@2ef5d2c6ccad:/srv/journal$ SCRIPT_FILENAME="/srv/journal/web/app.php" REQUEST_URI="/ping" REQUEST_METHOD=GET HTTP_HOST=localhost cgi-fcgi -bind -connect 127.0:9000 | grep pong
pong
```
Right now the empty string is detected as the `Host`, at least by `journal`; the healthcheck on `/ping` then fails with `400 Bad Request` since it's not in https://github.com/elifesciences/journal-formula/blob/31ad96a660e063eeb8e404857cd383265c4289e9/salt/journal/config/srv-journal-parameters.yml#L25-L30.