### PR TITLE
upgrades php-7.1.x-jessie to php-7.1.x-buster

### DIFF
--- a/Dockerfile.php_7.1_cli
+++ b/Dockerfile.php_7.1_cli
@@ -1,4 +1,4 @@
-FROM php:7.1.33-cli-stretch
+FROM php:7.1.33-cli-buster
 
 RUN apt-get update && apt-get install gnupg2 -y --no-install-recommends
 RUN docker-php-ext-install opcache

--- a/Dockerfile.php_7.1_cli
+++ b/Dockerfile.php_7.1_cli
@@ -1,7 +1,7 @@
 FROM php:7.1.33-cli-stretch
 
-RUN docker-php-ext-install \
-    opcache
+RUN apt-get update && apt-get install gnupg2 -y --no-install-recommends
+RUN docker-php-ext-install opcache
 
 COPY scripts/ /root/scripts
 RUN /root/scripts/setup-users-paths.sh

--- a/Dockerfile.php_7.1_cli
+++ b/Dockerfile.php_7.1_cli
@@ -1,4 +1,4 @@
-FROM php:7.1.28-cli-jessie
+FROM php:7.1.33-cli-stretch
 
 RUN docker-php-ext-install \
     opcache

--- a/Dockerfile.php_7.1_fpm
+++ b/Dockerfile.php_7.1_fpm
@@ -1,4 +1,4 @@
-FROM php:7.1.33-fpm-stretch
+FROM php:7.1.33-fpm-buster
 
 RUN apt-get update && apt-get install --no-install-recommends -y libfcgi0ldbl gnupg2
 RUN rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.php_7.1_fpm
+++ b/Dockerfile.php_7.1_fpm
@@ -1,10 +1,8 @@
 FROM php:7.1.33-fpm-stretch
 
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    libfcgi0ldbl \
-    && rm -rf /var/lib/apt/lists/* && \
-    docker-php-ext-install \
-    opcache
+RUN apt-get update && apt-get install --no-install-recommends -y libfcgi0ldbl gnupg2
+RUN rm -rf /var/lib/apt/lists/*
+RUN docker-php-ext-install opcache
 
 COPY scripts/ /root/scripts
 RUN /root/scripts/setup-users-paths.sh

--- a/Dockerfile.php_7.1_fpm
+++ b/Dockerfile.php_7.1_fpm
@@ -1,4 +1,4 @@
-FROM php:7.1.28-fpm-jessie
+FROM php:7.1.33-fpm-stretch
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     libfcgi0ldbl \


### PR DESCRIPTION
Changes the OS to `stretch` from `jessie` and the patch version of php 7.1 from `28` to `33`.

This may or may not fix the actual problem which is an old certificate bundle causing `curl` to barf.

fyi @giorgiosironi @thewilkybarkid 