### PR TITLE
Stop building images based on buster that have no obvious pathway to a newer supported debian

### DIFF
--- a/.github/workflows/build-and-push-php.yaml
+++ b/.github/workflows/build-and-push-php.yaml
@@ -19,7 +19,7 @@ jobs:
       cancel-in-progress: true
     strategy:
       matrix:
-        php_version: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php_version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php_version: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php_version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,7 @@ REPO_PREFIX=elifesciences/
 
 # these targets will build the php versions for your current platform and store them in the local docker
 # pushing isn't provided, as we want to push multi-arch manifests to the tags
-build-php: build-php-7.1 build-php-7.2 build-php-7.3 build-php-7.4 build-php-8.0 build-php-8.1 build-php-8.2 build-php-8.3 build-php-8.4
-build-php-7.1:
-	@$(MAKE) -f $(PHP_MAKEFILE) REPO_PREFIX=$(REPO_PREFIX) PHP_VERSION=7.1 build
-build-php-7.2:
-	@$(MAKE) -f $(PHP_MAKEFILE) REPO_PREFIX=$(REPO_PREFIX) PHP_VERSION=7.2 build
+build-php: build-php-7.3 build-php-7.4 build-php-8.0 build-php-8.1 build-php-8.2 build-php-8.3 build-php-8.4
 build-php-7.3:
 	@$(MAKE) -f $(PHP_MAKEFILE) REPO_PREFIX=$(REPO_PREFIX) PHP_VERSION=7.3 build
 build-php-7.4:
@@ -27,11 +23,7 @@ build-php-8.4: build-php-8.4
 	@$(MAKE) -f $(PHP_MAKEFILE) REPO_PREFIX=$(REPO_PREFIX) PHP_VERSION=8.4 build
 
 # run the baseline tests that the images run
-test-php: test-php-7.1 test-php-7.2 test-php-7.3 test-php-7.4 test-php-8.0 test-php-8.1 test-php-8.2 test-php-8.3 test-php-8.4
-test-php-7.1:
-	@$(MAKE) -f $(PHP_MAKEFILE) REPO_PREFIX=$(REPO_PREFIX) PHP_VERSION=7.1 test
-test-php-7.2:
-	@$(MAKE) -f $(PHP_MAKEFILE) REPO_PREFIX=$(REPO_PREFIX) PHP_VERSION=7.2 test
+test-php: test-php-7.3 test-php-7.4 test-php-8.0 test-php-8.1 test-php-8.2 test-php-8.3 test-php-8.4
 test-php-7.3:
 	@$(MAKE) -f $(PHP_MAKEFILE) REPO_PREFIX=$(REPO_PREFIX) PHP_VERSION=7.3 test
 test-php-7.4:
@@ -48,9 +40,7 @@ test-php-8.4:
 	@$(MAKE) -f $(PHP_MAKEFILE) REPO_PREFIX=$(REPO_PREFIX) PHP_VERSION=8.4 test
 
 # build and test targets
-build-and-test-php: build-and-test-php-7.1 build-and-test-php-7.2 build-and-test-php-7.3 build-and-test-php-7.4 build-and-test-php-8.0 build-and-test-php-8.1  build-and-test-php-8.2  build-and-test-php-8.3 build-and-test-php-8.4
-build-and-test-php-7.1: build-php-7.1 test-php-7.1
-build-and-test-php-7.2: build-php-7.2 test-php-7.2
+build-and-test-php: build-and-test-php-7.3 build-and-test-php-7.4 build-and-test-php-8.0 build-and-test-php-8.1  build-and-test-php-8.2  build-and-test-php-8.3 build-and-test-php-8.4
 build-and-test-php-7.3: build-php-7.3 test-php-7.3
 build-and-test-php-7.4: build-php-7.4 test-php-7.4
 build-and-test-php-8.0: build-php-8.0 test-php-8.0
@@ -61,11 +51,7 @@ build-and-test-php-8.4: build-php-8.4 test-php-8.4
 
 # these targets utilise docker buildx to build multi-arch images,
 # and push to docker hub (as local docker can't store multi-arch image manifest)
-buildx-and-push-php: buildx-and-push-php-7.1 buildx-and-push-php-7.2 buildx-and-push-php-7.3 buildx-and-push-php-7.4 buildx-and-push-php-8.0 buildx-and-push-php-8.1 buildx-and-push-php-8.2 buildx-and-push-php-8.3 buildx-and-push-php-8.4
-buildx-and-push-php-7.1:
-	@$(MAKE) -f $(PHP_MAKEFILE) COMMIT=$(COMMIT) REPO_PREFIX=$(REPO_PREFIX) PHP_VERSION=7.1 buildx
-buildx-and-push-php-7.2:
-	@$(MAKE) -f $(PHP_MAKEFILE) COMMIT=$(COMMIT) REPO_PREFIX=$(REPO_PREFIX) PHP_VERSION=7.2 buildx
+buildx-and-push-php: buildx-and-push-php-7.3 buildx-and-push-php-7.4 buildx-and-push-php-8.0 buildx-and-push-php-8.1 buildx-and-push-php-8.2 buildx-and-push-php-8.3 buildx-and-push-php-8.4
 buildx-and-push-php-7.3:
 	@$(MAKE) -f $(PHP_MAKEFILE) COMMIT=$(COMMIT) REPO_PREFIX=$(REPO_PREFIX) PHP_VERSION=7.3 buildx
 buildx-and-push-php-7.4:
@@ -80,7 +66,6 @@ buildx-and-push-php-8.3:
 	@$(MAKE) -f $(PHP_MAKEFILE) COMMIT=$(COMMIT) REPO_PREFIX=$(REPO_PREFIX) PHP_VERSION=8.3 buildx
 buildx-and-push-php-8.4:
 	@$(MAKE) -f $(PHP_MAKEFILE) COMMIT=$(COMMIT) REPO_PREFIX=$(REPO_PREFIX) PHP_VERSION=8.4 buildx
-
 
 build-python: build-python-3.8 build-python-3.9 build-python-3.10 build-python-3.11 build-python-3.12 build-python-3.13
 build-python-3.8:
@@ -109,10 +94,6 @@ test-python-3.12:
 	@$(MAKE) -f $(PYTHON_MAKEFILE) REPO_PREFIX=$(REPO_PREFIX) PYTHON_VERSION=3.12 test
 test-python-3.13:
 	@$(MAKE) -f $(PYTHON_MAKEFILE) REPO_PREFIX=$(REPO_PREFIX) PYTHON_VERSION=3.13 test
-
-# build and test targets
-build-and-test-php: build-and-test-php-7.1 build-and-test-php-7.2 build-and-test-php-7.3 build-and-test-php-7.4 build-and-test-php-8.0 build-and-test-php-8.1  build-and-test-php-8.2  build-and-test-php-8.3 build-and-test-php-8.4
-build-and-test-php-7.1: build-php-7.1 test-php-7.1
 
 build-and-test-python: build-and-test-python-3.8 build-and-test-python-3.9 build-and-test-python-3.10 build-and-test-python-3.11 build-and-test-python-3.12 build-and-test-python-3.13
 build-and-test-python-3.8: build-python-3.8 test-python-3.8

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ### Unified PHP image
 
-- [unified docker PHP image repository (with tags for `7.1-cli`, `7.1-fpm`, `7.3-cli`, `7.3-fpm`, `7.4-cli`, `7.4-fpm`, `8.0-cli`, `8.0-fpm`, `8.1-cli`, `8.1-fpm`, `8.2-cli`, `8.2-fpm`, `8.3-cli`, `8.3-fpm`, `8.4-cli` and `8.4-fpm)`](https://github.com/elifesciences/elife-base-images/pkgs/container/php)
+- [unified docker PHP image repository (with tags for `7.1-cli` (obsolete), `7.1-fpm` (obsolete), `7.2-cli` (obsolete), `7.2-fpm` (obsolete), `7.3-cli`, `7.3-fpm`, `7.4-cli`, `7.4-fpm`, `8.0-cli`, `8.0-fpm`, `8.1-cli`, `8.1-fpm`, `8.2-cli`, `8.2-fpm`, `8.3-cli`, `8.3-fpm`, `8.4-cli` and `8.4-fpm)`](https://github.com/elifesciences/elife-base-images/pkgs/container/php)
 
 NOTE: there is no `latest` tag - instead, specify the php version and `-cli` or `-fpm` sufix you desire, e.g. `docker pull ghcr.io/elifesciences/php:7.4-cli`
 NOTE2: pinning using sha digest is highly recommended

--- a/php_image_digests.txt
+++ b/php_image_digests.txt
@@ -1,9 +1,5 @@
 # THESE digests are read by Makefile-php to get a stable image
 
-PHP_IMAGE_7.1_cli=php:7.1-cli-buster@sha256:e0e6ced092bbf073e4f3e48545a8e1a2592217b3346ef0cb8b18ecacf8ae1522
-PHP_IMAGE_7.1_fpm=php:7.1-fpm-buster@sha256:8c526fa0d10f4cdb1db1dd6dc6c277fae74719bc7ea73b536ea16c389e3fe436
-PHP_IMAGE_7.2_cli=php:7.2-cli-buster@sha256:42ffbc0798e4449bbd1e14fc4dcb87774aa1ad1900a09ef6a965bc0880aa2161
-PHP_IMAGE_7.2_fpm=php:7.2-fpm-buster@sha256:9c84ae47fddb97b94d1d2e289635b7306142a5336bc4ece0a393458c5e0d2cef
 PHP_IMAGE_7.3_cli=php:7.3-cli-bullseye@sha256:bd6f2dc7a4e4537e927355c94a74c3022911aa504278f5f0fd94016c90dfaecc
 PHP_IMAGE_7.3_fpm=php:7.3-fpm-bullseye@sha256:2d68e401d2d3b9f8a6572791cd7a25062450c43ff52e58391146809741ad0885
 PHP_IMAGE_7.4_cli=php:7.4-cli-bullseye@sha256:620a6b9f4d4feef2210026172570465e9d0c1de79766418d3affd09190a7fda5


### PR DESCRIPTION

https://github.com/elifesciences/issues/issues/9347